### PR TITLE
Fix for pages that add styles to page that override benderjs results dashboard styles or page content overlaps results dashboard.

### DIFF
--- a/static/css/client.css
+++ b/static/css/client.css
@@ -43,6 +43,8 @@ body {
     list-style-type: none;
     margin: 0;
     padding: 56px 0 0;
+    z-index: 1000;
+    text-shadow: none;
 }
 
 .result {


### PR DESCRIPTION
Fix for pages that add styles to page that override benderjs results dashboard styles or page content overlaps results dashboard.
