### PR TITLE
T/227

### DIFF
--- a/lib/middlewares/tests.js
+++ b/lib/middlewares/tests.js
@@ -57,7 +57,7 @@ function build( bender ) {
 				.done( function( data ) {
 					bender.utils.renderJSON( res, {
 						test: data.map( function( test ) {
-							return _.pick( test, [ 'id', 'group', 'tags', 'unit', 'manual' ] );
+							return _.pick( test, [ 'id', 'displayName', 'group', 'tags', 'unit', 'manual' ] );
 						} )
 					} );
 				}, error );

--- a/lib/tests.js
+++ b/lib/tests.js
@@ -354,9 +354,12 @@ module.exports = {
 
 			_.forOwn( filelist.tests, function( test, id ) {
 				test.id = id.replace( /\\/g, '/' );
+				test.displayName = test.id;
 				test.framework = filelist.framework;
 				test.applications = applications;
 				test.group = filelist.name;
+
+				bender.emit( 'test:created', test );
 
 				tests.push( test );
 			} );

--- a/static/index.html
+++ b/static/index.html
@@ -88,7 +88,7 @@ Licensed under the terms of the MIT License (see LICENSE.md).
 	<!-- template for a single test row -->
 	<script type="text/html" id="test">
 	<tr data-id="<%= id %>" class="<%= getClass(result) %>">
-		<td><a href="/<%= id %>" title="<%= id %>" target="_blank"><%= id %></a></td>
+		<td><a href="/<%= id %>" title="<%= id %>" target="_blank"><%= displayName %></a></td>
 		<td title="<%= group %>"><%= group %></td>
 		<td title="<%= tags.join( ', ' ) %>"><%= tags.join( ', ' ) %></td>
 		<td class="result"><%= renderResult( result ) %></td>

--- a/static/index.html
+++ b/static/index.html
@@ -70,7 +70,7 @@ Licensed under the terms of the MIT License (see LICENSE.md).
 	<table class="table table-hover tests">
 		<thead class="fixed-header">
 			<tr>
-				<th class="col-md-5">ID</th>
+				<th class="col-md-5">Test</th>
 				<th class="col-md-1">Group</th>
 				<th class="col-md-2">Tags</th>
 				<th class="col-md-4">Status</th>

--- a/test/tests.js
+++ b/test/tests.js
@@ -35,36 +35,42 @@ describe( 'Tests', function() {
 	it( 'should list tests specified in the configuration file', function() {
 		var expected = [ {
 			id: 'test/fixtures/tests/test/1',
+			displayName: 'test/fixtures/tests/test/1',
 			js: path.normalize( 'test/fixtures/tests/test/1.js' ),
 			framework: 'test',
 			applications: [],
 			group: 'Test'
 		}, {
 			id: 'test/fixtures/tests/test/2',
+			displayName: 'test/fixtures/tests/test/2',
 			js: path.normalize( 'test/fixtures/tests/test/2.js' ),
 			framework: 'test',
 			applications: [],
 			group: 'Test'
 		}, {
 			id: 'test/fixtures/tests/test/3',
+			displayName: 'test/fixtures/tests/test/3',
 			js: path.normalize( 'test/fixtures/tests/test/3.js' ),
 			framework: 'test',
 			applications: [],
 			group: 'Test'
 		}, {
 			id: 'test/fixtures/tests/test2/1',
+			displayName: 'test/fixtures/tests/test2/1',
 			js: path.normalize( 'test/fixtures/tests/test2/1.js' ),
 			framework: 'test',
 			applications: [ 'test' ],
 			group: 'Test2'
 		}, {
 			id: 'test/fixtures/tests/test2/2',
+			displayName: 'test/fixtures/tests/test2/2',
 			js: path.normalize( 'test/fixtures/tests/test2/2.js' ),
 			framework: 'test',
 			applications: [ 'test' ],
 			group: 'Test2'
 		}, {
 			id: 'test/fixtures/tests/test2/3',
+			displayName: 'test/fixtures/tests/test2/3',
 			js: path.normalize( 'test/fixtures/tests/test2/3.js' ),
 			script: path.normalize( 'test/fixtures/tests/test2/3.md' ),
 			framework: 'test',
@@ -72,6 +78,7 @@ describe( 'Tests', function() {
 			group: 'Test2'
 		}, {
 			id: 'test/fixtures/tests/test2/4',
+			displayName: 'test/fixtures/tests/test2/4',
 			script: path.normalize( 'test/fixtures/tests/test2/4.md' ),
 			framework: 'test',
 			applications: [ 'test' ],

--- a/test/tests.js
+++ b/test/tests.js
@@ -91,6 +91,46 @@ describe( 'Tests', function() {
 			} );
 	} );
 
+	it( 'should fire `test:created` for every test created', function() {
+		var ids = [],
+			expected = [
+				'test/fixtures/tests/test/1',
+				'test/fixtures/tests/test/2',
+				'test/fixtures/tests/test/3',
+				'test/fixtures/tests/test2/1',
+				'test/fixtures/tests/test2/2',
+				'test/fixtures/tests/test2/3',
+				'test/fixtures/tests/test2/4'
+			];
+
+		// We don't expect the order to be the same, so we'll sort both lists.
+		expected.sort();
+
+		bender.on( 'test:created', function( test ) {
+			ids.push( test.id );
+		} );
+
+		return bender.tests.list()
+			.then( function() {
+				// Just like above, sort the result as we don't expect the order to match.
+				ids.sort();
+				expect( ids ).to.deep.equal( expected );
+			} );
+	} );
+
+	it( 'should allow changing test on `test:created`', function() {
+		bender.on( 'test:created', function( test ) {
+			test.testProperty = true;
+		} );
+
+		return bender.tests.list()
+			.then( function( tests ) {
+				tests.forEach( function( test ) {
+					expect( test ).to.have.property( 'testProperty' );
+				} );
+			} );
+	} );
+
 	it( 'should list tests using the cache for the second attempt', function() {
 		var stub = sinon.stub();
 


### PR DESCRIPTION
The proposal introduces the `displayName` property on tests, which is the used int he dashboard.

It also introduces the `test:created` event which can be used by plugins to customize anything in the test (including `displayName`).

With this code, I was able to implement the following in the CKEditor 5 plugin for Bender with this code:

```
bender.on( 'test:created', function( test ) {
	var name = test.displayName;

	name = name.replace( /node_modules\/ckeditor5-core/, 'core: ' );
	name = name.replace( /node_modules\/ckeditor5-plugin-([^\/]+)/, 'plugin!$1: ' );

	test.displayName = name;
} );
```

The outcome:

![image](https://cloud.githubusercontent.com/assets/630060/7608467/201f9450-f96a-11e4-8d9e-73682179ad10.png)
