### PR TITLE
Fix for incorrect rendering of spaces inside inline codes

### DIFF
--- a/static/css/manual.css
+++ b/static/css/manual.css
@@ -94,6 +94,7 @@ body {
 	background: #eee;
 	border: 1px solid #e7e7e7;
 	border-radius: 3px;
+	white-space: pre-wrap;
 }
 
 .manual-sidebar p code {


### PR DESCRIPTION
Simply adding `white-space: pre-wrap;` to CSS seems to do the trick.